### PR TITLE
Fix typo in LK06/exploit, "bap_map" to "bpf_map"

### DIFF
--- a/docs/linux-kernel/LK06/exploit.html
+++ b/docs/linux-kernel/LK06/exploit.html
@@ -285,7 +285,7 @@ eBPFではポインタに対するスカラー値の加減算が許可されて�
 <div class="balloon_l">
   <div class="faceicon"><img src="../img/wolf_suyasuya.png" alt="オオカミくん" ></div>
   <p class="says">
-    ALU sanitationがない時代は、この手法でbap_map構造体のopsなどを読み書きする攻撃が主流だったよ。
+    ALU sanitationがない時代は、この手法でbpf_map構造体のopsなどを読み書きする攻撃が主流だったよ。
   </p>
 </div>
 <h2 id="ALU-sanitationの回避">ALU sanitationの回避</h2>

--- a/website/source/linux-kernel/LK06/exploit.md
+++ b/website/source/linux-kernel/LK06/exploit.md
@@ -566,7 +566,7 @@ int main() {
 <div class="balloon_l">
   <div class="faceicon"><img src="../img/wolf_suyasuya.png" alt="オオカミくん" ></div>
   <p class="says">
-    ALU sanitationがない時代は、この手法でbap_map構造体のopsなどを読み書きする攻撃が主流だったよ。
+    ALU sanitationがない時代は、この手法でbpf_map構造体のopsなどを読み書きする攻撃が主流だったよ。
   </p>
 </div>
 


### PR DESCRIPTION
https://pawnyable.cafe/linux-kernel/LK06/exploit.html に、`bap_map` と記載されている部分があります。
念の為、Linux kernel 6.7.5 のソースコード内で `bap_map` を対象に全文検索をかけてみましたがヒットしませんでした。
おそらく `bpf_map` の typo と思うため、これを修正します。
